### PR TITLE
Remove anti-adblock from skrblik.cz

### DIFF
--- a/filters.txt
+++ b/filters.txt
@@ -1482,6 +1482,7 @@ jaguar-club.net#@#.reklama
 @@||i.imedia.cz/json*seznam.clanky.zpravy$script,domain=stream.cz
 ||onetv.cz/js/fuckadblock.js
 ||manmagazin.sk/wp-content/uploads/*/*.js?ver=2.0.11
+skrblik.cz#@##adsense
 
 !Titulky.com!
 titulky.com#@##reklama


### PR DESCRIPTION
Zneaktivňuje AdBlock Notify plugin, který po načtení překryje celou stránku a znemožní tak její použití. S touto úpravou se nezobrazují žádné reklamy ani anti-adblock hlášení.