### PR TITLE
Aktuálně.cz, přiliš široký blacklist

### DIFF
--- a/filters.txt
+++ b/filters.txt
@@ -737,7 +737,7 @@ abecedazahrady.dama.cz##.banneraltext
 abtou.cz##DIV[id^="simplemodal"]
 adfox.cz###vse
 aktualne.cz##A[href*="size=leader"]
-aktualne.cz###brand-c > div:first-child
+aktualne.cz###brand-c > div:first-child:not(.vse)
 aktualne.cz###reklama-halfpage
 aktualne.cz###reklama-megaboard
 aktualne.cz###reklama-wallpaper


### PR DESCRIPTION
Aktualne.cz: První div v .branc-c nemusí být reklama, občas to skryje celou stránku
Viz: https://zpravy.aktualne.cz/domaci/grafika-poslanci-koureni/r~7ff8feccbd1611e6bc740025900fea04/