### PR TITLE
Fix anti-adblock for poradte.cz

### DIFF
--- a/filters.txt
+++ b/filters.txt
@@ -1366,7 +1366,8 @@ titulky.com#@#.pub_728x90
 @@||bbelements.com/bb/bb_one2n.js$domain=titulky.com
 
 !poradte.cz!
-@@||poradte.cz/$genericblock,generichide
+@@||poradte.cz^$elemhide
+@@||poradte.cz/js/ads.js
 
 !idnes.cz!
 @@||bbelements.com$image,domain=idnes.cz


### PR DESCRIPTION
S předchozím filtrem vyskakovala chyba ohledně zapnutého adblocku, nyní jsou opět vidět odpovědi bez reklam. 
První pravidlo ošetřuje kontrolu přes FuckAdBlock
Druhé pravidlo ošetřuje ads.js, který obsahuje pouze definici proměnné k ověření, zda jsou reklamy skutečně povolené.