### PR TITLE
zablokovani videoreklam na idnes

### DIFF
--- a/filters.txt
+++ b/filters.txt
@@ -129,6 +129,8 @@ _clickthru.swf?
 ||bannery.ccb.cz^
 ||bbelements.com/bb/$script,third-party
 ||bbelements.com/please/showit/*/$script,domain=idnes.cz|moviezone.cz
+||adx.adform.net$domain=idnes.cz
+||ibillboard.com$domain=idnes.cz
 ||bcastgw.livebox.cz/TA3_VOD_COM/
 ||blisty.cz/ad/
 ||budejckadrbna.cz/files/drbna/banner/


### PR DESCRIPTION
spolehlive zablokuje videoreklamy, napriklad zde
https://technet.idnes.cz/foto.aspx?r=vojenstvi&c=A180918_120637_vojenstvi_kuz&foto=V180904_160405_technet_vrja