### PR TITLE
Remove ads on hnonline.sk

### DIFF
--- a/filters.txt
+++ b/filters.txt
@@ -384,8 +384,7 @@ _clickthru.swf?
 ||fs5.mojevideo.sk/securevd/siet.mp4
 ||gamesite.sk/templates/gamesite_sk/images/background*/
 ||hnonline.sk/*hn_lekaren_extra_blok.png
-||hnonline.sk/*/adId/*.mp4
-||*.hnonline.sk/*/adId/*.mp4
+||hnonline.sk/hn*/*/*hn$media
 ||hojko.com/images/banner*.gif
 ||i.sme.sk/fst/
 ||img.teevee.sk/img/beangel*.gif

--- a/filters.txt
+++ b/filters.txt
@@ -383,7 +383,7 @@ _clickthru.swf?
 ||fony.sk/content/banners/
 ||fs5.mojevideo.sk/securevd/siet.mp4
 ||gamesite.sk/templates/gamesite_sk/images/background*/
-||hnonline.sk/*hn_lekaren_extra_blok.png
+||hnonline.sk/hn*hnfiles/*.jpg
 ||hnonline.sk/hn*/*/*hn$media
 ||hojko.com/images/banner*.gif
 ||i.sme.sk/fst/


### PR DESCRIPTION
Updated filters for hnonline.sk - they have changed their ads URLs.