### PR TITLE
Added rule for partner.mrtns.eu

### DIFF
--- a/filters.txt
+++ b/filters.txt
@@ -519,6 +519,7 @@ _clickthru.swf?
 ||ls.hit.gemius.pl^$third-party
 ||netsuccess.sk^$third-party
 ||p1.naj.sk^$third-party
+||partner.mrtns.eu^$third-party
 ||recycle-static.zoznam.sk^$third-party
 ||rsz.sk^$third-party
 ||uspech.sk^$third-party


### PR DESCRIPTION
Odstráni reklamy ktoré pochádzajú z partnerského systému Martinusu