### PR TITLE
Gemius.pl removal

### DIFF
--- a/filters.txt
+++ b/filters.txt
@@ -1,7 +1,7 @@
 [Adblock Plus 2.0]
 ! Homepage: http://adblock.sk
 ! Title: Easylist Czech and Slovak filter list
-! Last change: 18/11/2018
+! Last change: 20/11/2018
 ! List maintainers: tomasko126, Aslanex, vobruba-martin, Moskoe, Fanboy
 ! GitHub repository: https://github.com/tomasko126/easylistczechandslovak
 ! GitHub contributors: https://github.com/tomasko126/easylistczechandslovak/graphs/contributors

--- a/filters.txt
+++ b/filters.txt
@@ -474,7 +474,6 @@ _clickthru.swf?
 ||inclick.sk^$third-party
 ||kariera.zoznam.sk/?page=banner$third-party
 ||login.dognet.sk/accounts/default1$third-party
-||gemius.pl^$third-party
 ||netsuccess.sk^$third-party
 ||p1.naj.sk^$third-party
 ||partner.mrtns.eu^$third-party


### PR DESCRIPTION
The gemius.pl rule should not be included in this filter list, because it is not serving ads but tracking scripts. That being said, tracking scripts should be reported to and included in the EasyPrivacy filter list.