### PR TITLE
Update filters.txt - get rid of whole-page ads on centrum.cz

### DIFF
--- a/filters.txt
+++ b/filters.txt
@@ -301,6 +301,7 @@ _clickthru.swf?
 ||warforum.cz/x2014/
 ||warzoneforum.eu/images/*banner.gif
 ||wesa.cz/banner/
+||xsd.cz/dist$domain=centrum.cz
 ||youradio.cz/api/triton/preroll
 ||zbynekmlcoch.cz/info/images/banners/*.swf
 ||zbynekmlcoch.cz/info/images/banners/banner_


### PR DESCRIPTION
get rid of whole-page ads on centrum.cz (you need to clear your cookies and refresh the page a few times to make sure the ad appears).
This probably brings their whole ad system down.