### PR TITLE
Výnimky pre bombuj.eu

### DIFF
--- a/filters.txt
+++ b/filters.txt
@@ -336,6 +336,9 @@ sluzebnik.cz#@##adverts
 ! ---------- Slovak Whitelisted blocking rules ------------ !
 !
 @@||bombuj.eu^$generichide
+@@||bombuj.eu/prehravace/overeniecaptcha3final.php
+@@||bombuj.eu/prehravace/openload.io.php
+@@||bombuj.eu/prehravace/verystream.com.php
 @@||img.aaaauto.eu/thumb/
 @@||pcforum.sk^$elemhide
 @@||pcforum.sk/styles/*/advertisement.js


### PR DESCRIPTION
Filter `||bombuj.eu/*.php$subdocument` v [internom uBlock filtri](https://github.com/uBlockOrigin/uAssets/blob/master/filters/filters.txt) blokuje aj stránky bez ktorých sa nenačíta prehrávanie na bombuj.eu. Tento PR pridáva výnimky pre tieto stránky.