### PR TITLE
Block custom Exponea implementation on o2.sk

### DIFF
--- a/filters.txt
+++ b/filters.txt
@@ -90,6 +90,7 @@
 ! ---------- Slovak 1st party blocking rules ---------- !
 !
 ||adb.azet.sk^
+||api-exponea.o2.sk^
 ||autobazar.eu/__branding/
 ||bmwklub.sk/images/banners/
 ||cucaj.sk/images/bannery/


### PR DESCRIPTION
Exponea service is used for tracking users, creating profiles and gathering all available personal and behavior information for creating personalized offers. Domain exponea.com is blocked by main easylist filter, but this service also offers implementation on custom domains. One of them is api-exponea.o2.sk used on multiple sites of O2 SK and CZ (for example o2.sk, o2vyhody.cz).