### PR TITLE
Remove cookie bar on o2.cz

### DIFF
--- a/filters.txt
+++ b/filters.txt
@@ -70,6 +70,7 @@
 ||mamincinyrecepty.cz/images/banner
 ||motorkari.cz^$subdocument
 ||mrk.cz/images/inz/
+||o2.cz/servis/cookie-bar.js
 ||pornuj.cz/files/ntva.php
 ||presentation.lmc.cz/aliance/
 ||prvnizpravy.cz/repository/banner


### PR DESCRIPTION
Script www.o2.cz/servis/cookie-bar.js displays annoying cookie confirmation on multiple O2 CZ sites: o2.cz, o2tv.cz, o2vyhody.cz, o2knihovna.cz, ...