### PR TITLE
Fix class selector for krimi-plzen.cz

### DIFF
--- a/filters.txt
+++ b/filters.txt
@@ -376,7 +376,7 @@ kladenskelisty.cz##.rright
 kladenskelisty.cz##.tree
 kniha.cz##div[id^="banner"]
 krimi-plzen.cz##a[rel="sponsored"]
-krimi-plzen.cz##[class*="partner"]
+krimi-plzen.cz##[class*="pаrtner"]
 kupi.cz##.top_background
 lamer.cz,moda.cz##.square
 letemsvetemapplem.eu###branding_conts


### PR DESCRIPTION
Fixes #319. The issue is that the actual class used on the site contains `\x0d\x0b` instead of the ascii `a`. Not sure if it's a typo or if it was intentional, but it was a fun bug to investigate.