### PR TITLE
Blokovanie reklám z web2media

### DIFF
--- a/filters.txt
+++ b/filters.txt
@@ -208,6 +208,7 @@
 ||productads.sk^$third-party
 ||recycle-static.zoznam.sk^$third-party
 ||robene.sk^$third-party
+||turbo.web2media.sk$third-party
 ||zachej.sk^$third-party
 !
 ! ---------- Czech Whitelisted blocking rules ------------ !


### PR DESCRIPTION
Pridaný 3rd-party filter pre blokovanie reklám z web2media - ako napríklad na stránke bbonline.sk