### PR TITLE
Blokovanie video reklam pre garaz.tv

### DIFF
--- a/filters.txt
+++ b/filters.txt
@@ -195,6 +195,7 @@
 ! ---------- Slovak 3rd party blocking rules ---------- !
 !
 ||ban.tipsport.sk^$third-party
+||firebasestorage.googleapis.com/v0/b/tivio-dev.appspot.com/*vast*.xml$third-party,domain=garaz.tv
 ||heureka.sk^$third-party
 ||imr.sk^$third-party
 ||inclick.sk^$third-party


### PR DESCRIPTION
Filter zablokuje reklamy tak ze blokne VAST XML definicie reklam pre video prehravac (ako napr.  https://firebasestorage.googleapis.com/v0/b/tivio-dev.appspot.com/o/assets%2Fstatic%2Fvast_garaztv_RENAULT_ARKANA_30s_16_9_SK_online.xml?alt=media )