### PR TITLE
Fix partner class for krimi-plzen.cz

### DIFF
--- a/filters.txt
+++ b/filters.txt
@@ -393,7 +393,7 @@ konzolista.cz##.ad
 konzolista.cz##.v-card.mb-6
 konzolista.cz##.v-card--link:-abp-has(.ad)
 krimi-plzen.cz##a[rel="sponsored"]
-krimi-plzen.cz##[class*="pаrtner"]
+krimi-plzen.cz##[class*="partnеr"]
 kupi.cz##.top_background
 kurzy.cz##[id^="adv_"]
 kurzy.cz###z990x200


### PR DESCRIPTION
I don't know if krimi-plzen.cz changed their classes again or what happened, but I remember they used different utf8 characters for their classes, so for example

`.sidebar-partner-box-top` if you write it by hand is just ascii chars, but what's on their website is `b'.sidebar-partn\xd0\xb5r-b\xce\xbfx-top'` (called `encode('utf8')` in Python). So the `e` and `o` are not ascii and therefore the current filter won't work.

The only way to make this work is to copy paste the exact class from source and use that until they change it again, unfortunately.