### PR TITLE
Configure GitHub Linguist

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# Override classification for *.txt files, so they are highlighted as adblock files.
+# By default, Adblock language doesn't show up in the repository's language statistics,
+# but adding linguist-detectable will resolve this.
+*.txt linguist-language=AdBlock linguist-detectable


### PR DESCRIPTION
This PR adds
- syntax highlight for https://github.com/tomasko126/easylistczechandslovak/blob/master/filters_ublock.txt
- "Adblock Filter List" to the repo statistics:
  ![image](https://github.com/tomasko126/easylistczechandslovak/assets/57285466/2191590f-137e-49f8-ab99-46bcc3909a58)
  - *Note*: It seems that the [`.tpl` file](https://github.com/tomasko126/easylistczechandslovak/blob/master/filters_ie.tpl) is detected as Smarty in the stats. Is this file really still needed? It hasn't been updated in 6 years and IE is also dead.

You can find more information about adblock syntax highlighting at the following link: https://github.com/AdguardTeam/VscodeAdblockSyntax#features