### PR TITLE
Blokovanie video reklam z tivio

### DIFF
--- a/filters.txt
+++ b/filters.txt
@@ -211,6 +211,7 @@
 ||productads.sk^$third-party
 ||recycle-static.zoznam.sk^$third-party
 ||robene.sk^$third-party
+||storage.googleapis.com/tivio-production.appspot.com/ads/$third-party
 ||turbo.web2media.sk$third-party
 ||zachej.sk^$third-party
 !


### PR DESCRIPTION
Zablokuje video reklamy na stranke garaz.tv a na inych strankach ktore vyuzivaju tivio