### PR TITLE
Block prebid-ads on eduself.sk

### DIFF
--- a/filters.txt
+++ b/filters.txt
@@ -108,6 +108,7 @@
 ||autobazar.eu/__branding/
 ||bannersector.sector.sk^
 ||bmwklub.sk/images/banners/
+||eduself.sk/public/js/prebid-ads.js$script,important
 ||flirtkontakt.sk/previews/banner*.jpg
 ||fony.sk/content/banners/
 ||fundingchoicesmessages.google.com$domain=hnonline.sk


### PR DESCRIPTION
Some parts of the site will disappear when adblock is detected, as explained here: https://www.eduself.sk/blokovanie-obsahu

This removes the script which handles and detects adblock.