### PR TITLE
Remove ticketportal carousels ads

### DIFF
--- a/filters.txt
+++ b/filters.txt
@@ -217,6 +217,7 @@
 ||recycle-static.zoznam.sk^$third-party
 ||robene.sk^$third-party
 ||storage.googleapis.com/tivio-production.appspot.com/ads/$third-party
+||ticketportal.sk/carousels^$third-party
 ||turbo.web2media.sk$third-party
 ||zachej.sk^$third-party
 !


### PR DESCRIPTION
Odstráni reklamy z ticketportalu ... aktuálne sú napr. na webe brainee.sk