### PR TITLE
tn.nova.cz adblock detection bypass

### DIFF
--- a/filters.txt
+++ b/filters.txt
@@ -75,6 +75,7 @@
 ||liveagent.mobilbonus.cz^
 ||lphard.cz/images/banners/
 ||mamincinyrecepty.cz/images/banner
+||mediatn.cms.nova.cz/robots.txt$xhr
 ||motorkari.cz^$subdocument
 ||mrk.cz/images/inz/
 ||parabola.cz/img_menu/*_01.$image


### PR DESCRIPTION
Bypass adblock detection.
URL: https://tn.nova.cz/auto/clanek/529608-sileny-rekord-tenhle-ridic-by-vam-nejspis-projel-i-dvermi-od-bytu
![tnNovaCz](https://github.com/tomasko126/easylistczechandslovak/assets/149894969/e566f13a-4c49-4bb2-a3d5-4d348bbcf38a)
