### PR TITLE
Seznam.cz "blocker" detection prevention

### DIFF
--- a/filters_ublock.txt
+++ b/filters_ublock.txt
@@ -15,6 +15,8 @@ enigmaplus.cz##img[src*="/img/atlas"]:upward(3)
 epochaplus.cz##img[alt="casopis"]:upward(3)
 epochaplus.cz##body:style(padding-top:0px !important;)
 games.tiscali.cz##+js(aopr, HTMLIFrameElement.prototype.contentWindow)
+||h.seznam.cz^$badfilter
+||h.seznam.cz/js/cmp2/$badfilter
 hokej.cz##+js(set, canRunAds, true)
 horoskopy.cz##+js(aopw, Fisher)
 ||idos.idnes.cz^$csp=child-src *

--- a/filters_ublock.txt
+++ b/filters_ublock.txt
@@ -16,7 +16,6 @@ epochaplus.cz##img[alt="casopis"]:upward(3)
 epochaplus.cz##body:style(padding-top:0px !important;)
 games.tiscali.cz##+js(aopr, HTMLIFrameElement.prototype.contentWindow)
 ||h.seznam.cz^$badfilter
-||h.seznam.cz/js/cmp2/$badfilter
 hokej.cz##+js(set, canRunAds, true)
 horoskopy.cz##+js(aopw, Fisher)
 ||idos.idnes.cz^$csp=child-src *


### PR DESCRIPTION
If these are blocked, you will get "Pravděpodobně používáte rozšíření či blokátory, jež mohou ovlivňovat načtení této stránky. Pro správnou funkčnost prosíme, deaktivujte všechna tato rozšíření a zkuste stránku načíst znovu." message, so I added this filter to prevent that. "Dan Pollock’s hosts file" for example has that domain, so if you have that filterlist enabled, it would totaly breaks the website, but with these filters it works again.
Also "AdGuard – Cookie Notices" filterlist broke the website too, so I added fix for that too (but they apparently already fixed it, but I´m going to keep this fix here just for case :) )