### PR TITLE
kurzy.cz

### DIFF
--- a/filters.txt
+++ b/filters.txt
@@ -71,6 +71,11 @@
 ||krimi-plzen.cz/media/partners/
 ||kurzy.cz/e/adv?
 ||img.kurzy.cz/og
+||kurzy.cz/l/s_back.js
+||img.kurzy.cz/block/
+kurzy.cz#$#cookie-remover /ab_1/;
+kurzy.cz#$#abort-on-property-write s_back
+@@img.kurzy.cz/ban/ad_ads_advert_advertisement_adform_pub_300x250.png
 ||lamer.cz/images/bg*.jpg
 ||letemsvetemapplem.eu/*/alzafeed_cached_js.php
 ||libise.eu/r/


### PR DESCRIPTION
detekuji adblock pres ad_ads_advert_advertisement_adform_pub_300x250.png, ukladaji info do cookie alia_ab_1 a vkladaji reklamy pres img.kurzy.cz/block/... pomoci s_back.js a objektu window.s_back