### PR TITLE
Bypass adblock detection at eduself.sk

### DIFF
--- a/filters.txt
+++ b/filters.txt
@@ -267,6 +267,7 @@ sluzebnik.cz#@##adverts
 ! ---------- Slovak Whitelisted blocking rules ------------ !
 !
 @@||admedia.joj.sk/outstream/embed?iframe$subdocument,domain=sport.aktuality.sk
+@@||ads.eduself.sk/_prebid.js
 @@||pravopisne.sk^$generichide
 @@||sledujserialy.to/theme/js/ads.js
 !


### PR DESCRIPTION
test url:
https://www.eduself.sk/slovensky-jazyk/tvary-slova/abakus

adds whitelist to:
https://ads.eduself.sk/_prebid.js?hash=skdjh

containing:
```js
var e=document.createElement('div');
e.id='ZwGYbAoajgQE';
e.style.display='none';
ab=false;
document.body.appendChild(e);
```

defuses:
```js
<script>
    if (!document.getElementById('ZwGYbAoajgQE'))
        ab = true;
</script>
```


alternative filter:
`www.eduself.sk##+js(set, ab, false)`

