### PR TITLE
fix titulky.com

### DIFF
--- a/filters.txt
+++ b/filters.txt
@@ -253,6 +253,7 @@ kurzy.cz#$#abort-on-property-write s_back
 @@||warforum.cz/ads.js
 @@||api.youradio.cz/v2/ads/preroll$xmlhttprequest
 @@||zdopravy.cz^$generichide
+@@||titulky.com/ads/titulky-ads-bottom.js
 !
 ! ---------- Czech Whitelisted hiding rules ---------- !
 !

--- a/filters_ublock.txt
+++ b/filters_ublock.txt
@@ -57,6 +57,7 @@ super.cz##+js(ra, style, body)
 svetandroida.cz##+js(aopr, detectAdBlocker)
 titulky.com##+js(ra, style, div[id^="head"])
 ||titulky.com/banalter/
+titulky.com###head_c:style(margin-top: 0 !important;)
 tn.nova.cz##+js(set, useSeznamAds, false)
 ||trackad.cz/adtrack.php$domain=nova.cz,script,redirect=noop.js
 uloz.to##div.l-wrapper:style(padding-top: 0px !important;)


### PR DESCRIPTION

## Summary

This pull request fixes anti-adblock filters for `titulky.com` website. Fixes #446

added filters:
```
@@||www.titulky.com/ads/titulky-ads-bottom.js
titulky.com###head_c:style(margin-top: 0 !important;)
```

## Anti adblock detection

`/ads/titulky-ads-bottom.js`:

```js
var showBanner600=true;
var showBanner700=true;
var showBanner735=true;
var showFairUser=true;
bannerSkyscraperHeight='600px';
verTimer=2.01;
console.log("Titulky.com verTimer: " + verTimer);
```


`/Ludwig-nejnovejsi-406670.htm`:

```js
if(typeof showFairUser !== 'undefined' && showFairUser){
	console.log("Good user!");
	var adbUser=false;
}else{
	showFairUser=false;
	console.log("Poor user!");	
	var adbUser=true;
}
```


`/Ludwig-nejnovejsi-406670.htm`:

```js
<script>
	$(".titulkydownloadajax").each(function() {
	  ...
	  adbUser && $(this).parent().html('<div class="adbdown" onclick="showADowninfo()"...
	  ...
	});
</script>
```


by whitelisting `/ads/titulky-ads-bottom.js`, all required variables are correctly set and no ads are shown


### Test

open devtools, if the filters worked, you should see `Good user!` in the console. If you try to download subtitles, you see download link instead of `zablokovaná reklama` text.


## Cosmetic filter

Blocking top navigation bar ad by filter ads/easylist moves top navigation panel out of the screen, this filter fixes it.

`titulky.com###head_c:style(margin-top: 0 !important;)`


### Test

Top navigation panel is visible on the screen


## Tested on

- manifest v2 ublock origin
- chrome
- enabled filter lists:
	- ublock built-in / all
	- ads / easylist (this filter blocks top ad, cosmetic filter in this pull requests fixes top navigation panel position)
	- privacy / easyprivacy (this filter blocks sidebar ad)





---------


