### PR TITLE
fix titulky.com v2

### DIFF
--- a/filters.txt
+++ b/filters.txt
@@ -253,7 +253,7 @@ kurzy.cz#$#abort-on-property-write s_back
 @@||warforum.cz/ads.js
 @@||api.youradio.cz/v2/ads/preroll$xmlhttprequest
 @@||zdopravy.cz^$generichide
-@@||titulky.com/ads/titulky-ads-bottom.js
+@@||titulky.com/ads/titulky-ads-banner.js
 !
 ! ---------- Czech Whitelisted hiding rules ---------- !
 !

--- a/filters.txt
+++ b/filters.txt
@@ -265,6 +265,7 @@ novinky.cz#@#.g_ad
 www.parabola.cz#@#.rklm
 skrblik.cz#@##adsense
 sluzebnik.cz#@##adverts
+titulky.com#@#div#adBar
 !
 ! ---------- Slovak Whitelisted blocking rules ------------ !
 !
@@ -502,6 +503,7 @@ telekomunikace.cz##.Flagrow-Ads-under-header
 tipcars.com##.amalker
 tiscali.cz##.bbtitle
 titulky.com###pagefoot
+titulky.com###brny300x300
 topzine.cz###vyjizdeciBoxikDiv
 tryhard.cz##[class*="sda-"]
 tv.seznam.cz##div[class^="branding-ad"]

--- a/filters_ublock.txt
+++ b/filters_ublock.txt
@@ -57,7 +57,6 @@ super.cz##+js(ra, style, body)
 svetandroida.cz##+js(aopr, detectAdBlocker)
 titulky.com##+js(ra, style, div[id^="head"])
 ||titulky.com/banalter/
-titulky.com###head_c:style(margin-top: 0 !important;)
 tn.nova.cz##+js(set, useSeznamAds, false)
 ||trackad.cz/adtrack.php$domain=nova.cz,script,redirect=noop.js
 uloz.to##div.l-wrapper:style(padding-top: 0px !important;)


### PR DESCRIPTION
## Summary

This pull request fixes anti-adblock filters for `titulky.com` website (again). The same detection and testing method as described in #447, just the url was changed from `/ads/titulky-ads-bottom.js` to `/ads/titulky-ads-banner.js`

changed filters:

```diff
- @@||titulky.com/ads/titulky-ads-bottom.js
+ @@||titulky.com/ads/titulky-ads-banner.js
```


## Test

you should see `Good user!` printed in the console


## Tested on

- chrome + manifest v2 ublock origin
- enabled filter lists:
	- ublock built-in / all
	- ads / easylist (required to block top ad)
	- privacy / easyprivacy (required to block sidebar ad)