### PR TITLE
fix titulky.com v4

### DIFF
--- a/filters.txt
+++ b/filters.txt
@@ -101,6 +101,7 @@ kurzy.cz#$#abort-on-property-write s_back
 ||stat.novinky.cz^
 ||stat.super.cz^
 ||stobklub.cz/images/banners/maintop.jpg
+titulky.com/mybannalter/
 ||tracker.cncenter.cz^
 ||uschovna.cz/branding
 ||vascak.cz/data/img/adblock.png$image
@@ -205,6 +206,7 @@ kurzy.cz#$#abort-on-property-write s_back
 ||sda.online-systemy.cz^$third-party
 ||sda.un-42.com^$third-party
 ||storage.googleapis.com/adela-hb-platform.appspot.com/$third-party
+||titulky.com^$third-party
 ||trackad.cz^$third-party
 ||viadata.store^$third-party
 ||xzone.cz^$third-party
@@ -253,7 +255,7 @@ kurzy.cz#$#abort-on-property-write s_back
 @@||warforum.cz/ads.js
 @@||api.youradio.cz/v2/ads/preroll$xmlhttprequest
 @@||zdopravy.cz^$generichide
-@@||titulky.com/ads/titulky-ads-banner.js
+@@||titulky.com^$generichide
 !
 ! ---------- Czech Whitelisted hiding rules ---------- !
 !
@@ -265,7 +267,6 @@ novinky.cz#@#.g_ad
 www.parabola.cz#@#.rklm
 skrblik.cz#@##adsense
 sluzebnik.cz#@##adverts
-titulky.com#@##AdBanner
 !
 ! ---------- Slovak Whitelisted blocking rules ------------ !
 !
@@ -502,8 +503,8 @@ super.cz##a[data-dot="c_pozadi"]
 telekomunikace.cz##.Flagrow-Ads-under-header
 tipcars.com##.amalker
 tiscali.cz##.bbtitle
-titulky.com###pagefoot
-titulky.com###brnny300x300
+titulky.com##.pagefoot
+titulky.com###bnrcust300x300
 topzine.cz###vyjizdeciBoxikDiv
 tryhard.cz##[class*="sda-"]
 tv.seznam.cz##div[class^="branding-ad"]

--- a/filters_ublock.txt
+++ b/filters_ublock.txt
@@ -55,8 +55,6 @@ search.seznam.cz,clanky.seznam.cz##div[data-e-b-n*="advert"]
 sreality.cz##+js(nosiif, checkRods)
 super.cz##+js(ra, style, body)
 svetandroida.cz##+js(aopr, detectAdBlocker)
-titulky.com##+js(ra, style, div[id^="head"])
-||titulky.com/banalter/
 tn.nova.cz##+js(set, useSeznamAds, false)
 ||trackad.cz/adtrack.php$domain=nova.cz,script,redirect=noop.js
 uloz.to##div.l-wrapper:style(padding-top: 0px !important;)


### PR DESCRIPTION
## Summary

The site owner updated most of his anti-adblock detection 3 hours ago with some changes 2 hours ago, so more fixes had do be done. Now the filters are more generic. I also removed obsolete filters and updated filter to hide footer ads. 

Note that the site randomly chooses between 3-rd party and 1-st party ads in the 300x300 spot. You may need more refreshes to get the 1-st party ad

## Tested on

- chrome + manifest v2 ublock origin
- enabled filter lists:
	- ublock built-in / all
	- ads / easylist
	- privacy / easyprivacy