### PR TITLE
titulky.com abp compatibility

### DIFF
--- a/filters.txt
+++ b/filters.txt
@@ -255,6 +255,7 @@ titulky.com/mybannalter/
 @@||warforum.cz/ads.js
 @@||api.youradio.cz/v2/ads/preroll$xmlhttprequest
 @@||zdopravy.cz^$generichide
+@@||titulky.com^$genericblock
 @@||titulky.com^$generichide
 !
 ! ---------- Czech Whitelisted hiding rules ---------- !


### PR DESCRIPTION
## Summary

This pull request fixes compatibility with adblock plus

It looks like adblock plus needs additional `genericblock` whitelisting rule to ignore generic network rules. Ublock origin will happily ignore that rule, because that behaviour it already a part of  `generichide`.

## Tested on

- adblock plus mv2 chrome
- ublock origin mv2 chrome
- brave


