### PR TITLE
fix titulky.com v7

### DIFF
--- a/filters.txt
+++ b/filters.txt
@@ -255,7 +255,7 @@ titulky.com/banaltr/
 @@||warforum.cz/ads.js
 @@||api.youradio.cz/v2/ads/preroll$xmlhttprequest
 @@||zdopravy.cz^$generichide
-@@||titulky.com/titulkycom-ads-banner.js
+@@||titulky.com/ads/titulkycom-ads-banner.js
 @@||titulky.com^$generichide
 !
 ! ---------- Czech Whitelisted hiding rules ---------- !
@@ -268,7 +268,7 @@ novinky.cz#@#.g_ad
 www.parabola.cz#@#.rklm
 skrblik.cz#@##adsense
 sluzebnik.cz#@##adverts
-titulky.com#@##AD_ROW
+titulky.com#@##AdBigBox
 !
 ! ---------- Slovak Whitelisted blocking rules ------------ !
 !

--- a/filters_ublock.txt
+++ b/filters_ublock.txt
@@ -55,6 +55,8 @@ search.seznam.cz,clanky.seznam.cz##div[data-e-b-n*="advert"]
 sreality.cz##+js(nosiif, checkRods)
 super.cz##+js(ra, style, body)
 svetandroida.cz##+js(aopr, detectAdBlocker)
+titulky.com##+js(set, scriptSZ, undefined)
+titulky.com##+js(set, showFairUser001, true)
 tn.nova.cz##+js(set, useSeznamAds, false)
 ||trackad.cz/adtrack.php$domain=nova.cz,script,redirect=noop.js
 uloz.to##div.l-wrapper:style(padding-top: 0px !important;)


### PR DESCRIPTION
## Summary

We are still bypassing with ublock origin, this pull request fixes adblock plus. Also addresses incorrect bait url mentioned in [uBlockOrigin/uAssets/issues/26685](https://github.com/uBlockOrigin/uAssets/issues/26685#issuecomment-2567095486) and prevent's leaking adblock use to the server side (ublock origin only)