### PR TITLE
fix krimi-plzen.cz

### DIFF
--- a/filters.txt
+++ b/filters.txt
@@ -67,7 +67,6 @@
 ||jiskra-benesov.cz/images/branding/
 ||jiskra-benesov.cz/webloader/jsloader-*.js
 ||js.tipcars.com/js/*/_view/amalker/amalker.js
-||krimi-plzen.cz/media/partners/
 ||kurzy.cz/e/adv?
 ||img.kurzy.cz/og
 ||kurzy.cz/l/s_back.js
@@ -435,8 +434,12 @@ kladenskelisty.cz##.faderandom
 kniha.cz##div[id^="banner"]
 konzolista.cz##.ad
 konzolista.cz##.v-card.mb-6
-krimi-plzen.cz##a[rel="sponsored"]
-krimi-plzen.cz##[class*="partnеr"]
+krimi-plzen.cz##.partnｅr-bοx
+krimi-plzen.cz##.article-list-partnｅr-slіder
+krimi-plzen.cz##.article-list-partnｅr-slіder-label
+krimi-plzen.cz##.article-list-partnｅr-slіder-controls
+krimi-plzen.cz##.article-partnｅr-bοx
+krimi-plzen.cz##.ad-seznam-responsive
 kupi.cz##.top_background
 kurzy.cz##[id^="adv_"]
 kurzy.cz###z990x200


### PR DESCRIPTION
## Summary

Removes multiple ad spots, some on homepage, some in the article view.
Note: the site used non-ascii `ｅ` to bypass previous filter  (`partnｅr`)

Also removed unused filters