### PR TITLE
add ban.tipsport.cz

### DIFF
--- a/filters.txt
+++ b/filters.txt
@@ -166,6 +166,7 @@ titulky.com/banaltr/
 ||ads.esports.cz^$third-party
 ||adverts.cz^$third-party
 ||automodul.cz^$third-party
+||ban.tipsport.cz^$third-party
 ||banan.cz^$third-party
 ||banner.ifortuna.cz^$third-party
 ||banners.onebit.cz^$third-party


### PR DESCRIPTION
## Summary

This filter adds ban.tipsport.cz - serving only banners as a third-party. There is already a similar filter `||ban.tipsport.sk^$third-party`, this one is the same for the czech domain.

Example of a site, where these banners are served: https://www.onlajny.com/ (see background ad on the desktop)