### PR TITLE
fix programujte.com

### DIFF
--- a/filters.txt
+++ b/filters.txt
@@ -136,6 +136,7 @@ titulky.com/banaltr/
 ||ourphorum.com/images/banner
 ||pricemania.sk/pictures/banners/
 ||pricemania.sk/pictures/campaigns/
+programujte.com/img/pozadi_2024.jpg
 ||radia.sk/_uputavky/$subdocument
 ||radia.sk/scripts/ads.js
 ||recycle.zoznam.sk/get.fcgi


### PR DESCRIPTION
Additional filter to hide background alza ad (desktop only). Old filters are up-to-date.