### PR TITLE
add warcenter.cz

### DIFF
--- a/filters.txt
+++ b/filters.txt
@@ -105,6 +105,7 @@ titulky.com/banaltr/
 ||uschovna.cz/branding
 ||vascak.cz/data/img/adblock.png$image
 ||videoad.cz^
+warcenter.cz/interstitial_fs.js
 ||warforum.cz/ads/$image
 ||wesa.cz/banner/
 ||*/wp-content/plugins/wp-content-copy-protection/assets/js/script.min.js$domain=rozbor-dila.cz|rozbor-dila.eu|rozborknihy.cz|studijni-svet.cz|ekonomie-ucetnictvi.cz|biologie-chemie.cz|anglictina-maturita.cz
@@ -522,6 +523,7 @@ tvfreak.cz##.skyscrapper-right
 uschovna.cz##.branding-link
 vortex.cz##.banner-brand
 war4all.com###tblHorniLista
+warcenter.cz##td[bgcolor="#066490"]
 warezforum.cz##.center
 warezforum.cz##object[id*="bfad"]
 warforum.cz###adLocation-21


### PR DESCRIPTION
Hides fastshare ads on warcenter.cz:
- `warcenter.cz##td[bgcolor="#066490"]` - blocks banner ad on the top of the page
- `warcenter.cz/interstitial_fs.js` blocks modal ad - note: it shows only on the first load, clear cookies to see it again

interstitial.js is a generic ad script for fastshare ads, we already block it on sktorrent.eu site