### PR TITLE
add fastshare.cloud

### DIFF
--- a/filters.txt
+++ b/filters.txt
@@ -178,6 +178,7 @@ titulky.com/banaltr/
 ||dot.idot.cz^$third-party
 ||ecigareta.eu^$third-party
 ||ehub.cz^$third-party
+||fastshare.cloud^$third-party
 ||fastshare.cz^$third-party
 ||graphics.stdout.cz/b:commercial$third-party
 ||heureka.cz^$third-party


### PR DESCRIPTION
fastshare.cz has another domain, which serves third-party ads - fastshare.cloud

Example of a site, where ads are served from fastshare.cloud: warforum.xyz