### PR TITLE
add hlavnydennik.sk

### DIFF
--- a/filters.txt
+++ b/filters.txt
@@ -582,6 +582,7 @@ cp.sk##.advert
 cp.sk##.banner
 dsl.sk##.header_info_text
 feminity.zoznam.sk##div[class*="pohodoWidget"]
+hlavnydennik.sk##.container[style="text-align: center; margin-bottom: 50px;"]
 hnonline.sk##[id^="banner-"]
 hnonline.sk##.s-branding
 hnonline.sk##stripemark


### PR DESCRIPTION
Hides sns ad on top of the homepage

warning - disinformation website according to https://konspiratori.sk/zoznam-stranok