### PR TITLE
add hlavnespravy.sk

### DIFF
--- a/filters.txt
+++ b/filters.txt
@@ -415,6 +415,13 @@ hcmotor.cz##div.container.partners
 heureka.cz,heureka.sk##.filtr.category-partner
 heureka.cz,heureka.sk##div[class*="__banner"]
 heureka.cz,heureka.sk##div[class$="advert"]
+hlavnespravy.sk###text-2
+hlavnespravy.sk##ins.main-content 
+hlavnespravy.sk##.block.block2>.sidebar
+hlavnespravy.sk##.block.block3>.sidebar
+hlavnespravy.sk##.block.block4>.sidebar
+hlavnespravy.sk##.subscribe-overlay
+hlavnespravy.sk##.subscribe-overlay-desktop
 hrej.cz##[class*="sda-"]
 hybrid.cz##.TopFullBanner
 idnes.cz##div[id^="hyper"]


### PR DESCRIPTION
- Add cosmetic filters to remove whitespace after ads were removed by generic filters
- Removes subscribe nags

warning - disinformation website according to https://dennikn.sk/blog/1775813/sud-prikazal-konspiratorom-docasne-stiahnut-web-hlavnespravy-sk-zo-svojej-databazy/