### PR TITLE
fix horoskopy.cz

### DIFF
--- a/filters.txt
+++ b/filters.txt
@@ -62,6 +62,7 @@
 ||hd-forum.cz/images/banner/
 ||hd-forum.cz/images/sberbank.jpg
 ||heureka.cz/direct/bannery/
+horoskopy.cz/*/static/js/ssp.js?szn_loader=1
 ||im9.cz/*aukro
 ||img.cdnprg.webtea.cz/web/pozadi_webu_mc.jpg
 ||jiskra-benesov.cz/images/branding/

--- a/filters_ublock.txt
+++ b/filters_ublock.txt
@@ -17,7 +17,6 @@ ewrc.cz##+js(set, checkAdsBlocked, noopFunc)
 games.tiscali.cz##+js(aopr, HTMLIFrameElement.prototype.contentWindow)
 ||h.seznam.cz^$badfilter
 hokej.cz##+js(set, canRunAds, true)
-horoskopy.cz##+js(aopw, Fisher)
 ||idos.idnes.cz^$csp=child-src *
 impuls.cz##+js(set, first, false)
 ||indian-tv.cz/uploads/$document


### PR DESCRIPTION
Hides all ads by blocking seznam.cz ad script. We can't block seznam.cz entirely, because the site forces cookie consent throught seznam.cz.

Also removed old filter 