### PR TITLE
fix markiza.sk

### DIFF
--- a/filters_ublock.txt
+++ b/filters_ublock.txt
@@ -29,6 +29,7 @@ letemsvetemapplem.eu,samsungmagazine.eu##.headerbanner-wrapper:style(min-height:
 letemsvetemapplem.eu,samsungmagazine.eu,androidmagazine.eu##header.lsa:style(margin-top: 0 !important;)
 letemsvetemapplem.eu,samsungmagazine.eu,androidmagazine.eu,jablickar.cz###page_wrapper:style(cursor: auto !important;)
 lupa.cz##+js(nofab)
+markiza.sk##+js(nano-stb,t(), *)
 media.joj.sk##+js(set, settings.ads, false)
 media.joj.sk##+js(set, Rmp.params.genderSelectionUrl, undefined)
 mobilenet.cz,fzone.cz,fdrive.cz##+js(set, App.pos.init, noopFunc)


### PR DESCRIPTION
If the video player detects adblock, it won't play a video for 15 seconds. This filter removes this artificial delay.

Also they still bait `https://static.ads-twitter.com/uwt.js`, so the old filters are still needed

Testing url with a video:
https://www.markiza.sk/soubiz/clanok/946807-zasnubami-sa-to-nekonci-dara-rolins-prezradila-dalsiu-velku-novinku