### PR TITLE
fix hnonline.sk v2

### DIFF
--- a/filters.txt
+++ b/filters.txt
@@ -241,6 +241,7 @@ programujte.com/img/pozadi_2024.jpg
 !
 @@||*-reklama.cz
 @@||bmw-club.cz^$generichide
+@@cdn.cpex.cz/cmp/v2/cpex-cmp.min.js$domain=hnonline.sk
 @@cdn.cxense.com/cx.cce.js$domain=hnonline.sk
 @@cdn.cxense.com/cx.js$domain=hnonline.sk
 @@api.cxense.com/public/widget/data$domain=hnonline.sk


### PR DESCRIPTION
The site didn't update their code, I just made a mistake in #477. We have to whitelist one more url, because our 1st party filter `||cdn.cpex.cz^` blocks it. The site doesn't show ads even with this url whitelisted with default ublock filters + our filterlist.

Testing procedure is unchanged #477 -  check if 24 hour / 3 days / 7 days suggestions are loaded in any [article page](https://hnonline.sk/finweb/ekonomika/96189221) 