### PR TITLE
fix hnonline.sk v3

### DIFF
--- a/filters.txt
+++ b/filters.txt
@@ -129,6 +129,7 @@ warcenter.cz/interstitial_fs.js
 ||mojanitra.sk/banery/
 ||mojanitra.sk//images/banery/
 ||ourphorum.com/images/banner
+code.piano.io/api/tinypass.min.js$domain=hnonline.sk
 ||pricemania.sk/pictures/banners/
 ||pricemania.sk/pictures/campaigns/
 programujte.com/img/pozadi_2024.jpg
@@ -235,10 +236,6 @@ programujte.com/img/pozadi_2024.jpg
 !
 @@||*-reklama.cz
 @@||bmw-club.cz^$generichide
-@@cdn.cpex.cz/cmp/v2/cpex-cmp.min.js$domain=hnonline.sk
-@@cdn.cxense.com/cx.cce.js$domain=hnonline.sk
-@@cdn.cxense.com/cx.js$domain=hnonline.sk
-@@api.cxense.com/public/widget/data$domain=hnonline.sk
 @@||decko.ceskatelevize.cz/cms/layouts/js/analytics.js$script,domain=decko.ceskatelevize.cz
 @@||heureka.*/crossdomain.xml
 @@||heureka.*/direct/vyvoj-cen/
@@ -271,6 +268,10 @@ sluzebnik.cz#@##adverts
 !
 @@||admedia.joj.sk/outstream/embed?iframe$subdocument,domain=sport.aktuality.sk
 @@||ads.eduself.sk/_prebid.js
+@@cdn.cpex.cz/cmp/v2/cpex-cmp.min.js$domain=hnonline.sk
+@@cdn.cxense.com/cx.cce.js$domain=hnonline.sk
+@@cdn.cxense.com/cx.js$domain=hnonline.sk
+@@api.cxense.com/public/widget/data$domain=hnonline.sk
 @@||pravopisne.sk^$generichide
 @@||sledujserialy.to/theme/js/ads.js
 !

--- a/filters_ublock.txt
+++ b/filters_ublock.txt
@@ -42,6 +42,7 @@ parlamentnilisty.cz##+js(aopr, Ads)
 podcasty.seznam.cz##+js(set, sssp.config, noopFunc)
 podcasty.seznam.cz##+js(set, sssp, {})
 pppeter.shop##body:remove-class(modal-open)
+code.piano.io/api/tinypass.min.js$domain=hnonline.sk,badfilter
 prehrajto.cz##.content:style(margin-top: 0px !important;)
 ||r.i0.cz^$3p,image,redirect=1x1.gif
 root.cz##+js(set, Gallery.prototype.setAdsForGallery, noopFunc)


### PR DESCRIPTION
I have been thinking about how to defuse the anti-adblock lock for this site for adblock plus users. You can defuse the lock by blocking `tinypass.min.js`, but that breaks some site functionality (like the suggested articles). But better to have degraded functionality than no functionality at all. Blocking `tinypass.min.js` will also break site functionality for ublock origin users, who can bypass the lock by more elegant filters and have a fully functional site.

So I came up with an idea to block it in the main filters (for adblock plus), but disable it by using `badfilter` it in ublock filters. So users of both blockers can have the best possible experience.

To reproduce the lock, use empty profile with adblock plus installed with default filter lists + out filter list. Then click on articles till it appears (it doesn't appear immediately). It will set `__adblocker` cookie to `true` and won't allow you to continue if you don't disable your content blocker. Ian't hide the modal with basic filters, because they also disable the page scroll.

I also moved the previous filters to the slovak section

What do you think?