### PR TITLE
Fix parabola.cz articles

### DIFF
--- a/filters.txt
+++ b/filters.txt
@@ -264,6 +264,7 @@ denik.cz#@#.reklama-box
 hyundai.com#@#.r-main
 jaguar-club.net,mazdaclub.cz,nissanclub.cz#@#.reklama
 novinky.cz#@#.g_ad
+www.parabola.cz#@#.rklm
 skrblik.cz#@##adsense
 sluzebnik.cz#@##adverts
 !


### PR DESCRIPTION
I have returned `.rklm` whitelist filter for `parabola.cz` back after removing in #469, since the article contents won't load without it.