### PR TITLE
fix lidovky.cz

### DIFF
--- a/filters.txt
+++ b/filters.txt
@@ -453,6 +453,16 @@ kurzy.cz##.ecb.loga-partneru
 kurzy.cz###wise-calc-widget
 lamer.cz##.square
 lidovky.cz##div[id^="hyper"]
+lidovky.cz###main>table
+lidovky.cz##body::before
+lidovky.cz###waiting-screen
+lidovky.cz##div:has(>div>div>a[href^="https://servix.idnes.cz"])
+lidovky.cz###rmegovka-sph
+lidovky.cz##.col-foto:style(margin-right:0px !important)
+lidovky.cz##div[data-redistribute="ad"]
+lidovky.cz##div:has(>.r-head>span)
+lidovky.cz,www.idnes.cz##div:has(>a[data-js-xhr="1"]>img.block.full.mbrem)
+idnes.cz###extra-tab
 matematika.cz###box-3
 matematika.cz###rbackground-link
 matematika.cz##div[id*="reklama"]


### PR DESCRIPTION
Fixes #514

Blocks all ads on mobile+desktop version of lidovky.cz I could find. I found the same banner ad on idnes.cz, so I added it to the filter.

I have hidden the loading screen, because the site in not happy that it cannot load the ads [in the gallery](https://www.lidovky.cz/nazory/donald-trump-maga-baseballova-cepice-andrej-babis-silne-cesko.A250408_155018_ln_nazory_lgs/foto/LRO8c9e49_veis2ab.jpg) and it will never hide the loader if you try to switch to the next image on the desktop version of the site.

To test the mobile site, toggle the mobile emulator in the browser, **clear cookies** and then refresh the site. The site won't toggle to mobile view if you don't clear cookies.

We are still bypassing the anti-adblock popup (ublock origin mv2). The forced GDPR "consent" is still working.