### PR TITLE
fix forced markíza ads in magio.tv archive

### DIFF
--- a/filters_ublock.txt
+++ b/filters_ublock.txt
@@ -28,6 +28,7 @@ letemsvetemapplem.eu,samsungmagazine.eu##.headerbanner-wrapper:style(min-height:
 letemsvetemapplem.eu,samsungmagazine.eu,androidmagazine.eu##header.lsa:style(margin-top: 0 !important;)
 letemsvetemapplem.eu,samsungmagazine.eu,androidmagazine.eu,jablickar.cz###page_wrapper:style(cursor: auto !important;)
 lupa.cz##+js(nofab)
+magio.tv##+js(json-prune-xhr-response, adBlocks.[-].id, , propsToMatch, /schedules/ads)
 markiza.sk,tvnoviny.sk##+js(nano-stb,t(), *)
 media.joj.sk##+js(set, settings.ads, false)
 media.joj.sk##+js(set, Rmp.params.genderSelectionUrl, undefined)


### PR DESCRIPTION
With this filter, user is able to skip forward 3-minute forced markíza ads in magio.tv archive. 