### PR TITLE
Block ads on "Bakaláři" instances

### DIFF
--- a/filters.txt
+++ b/filters.txt
@@ -44,6 +44,7 @@
 ||bannery.navratdoreality.cz^
 ||bcastgw.livebox.cz/TA3_VOD_COM/
 ||c.seznam.cz^
+||campaign.bakalari.cz^
 ||cdr.cz/sites/default/files/_cdr_branding/branding.jpg
 ||cdn.cpex.cz^
 ||cdn.dopc.cz/adb$xmlhttprequest


### PR DESCRIPTION
Blocking `campaign.bakalari.cz` completely removes all of the ads from the page (yes, they seriously added some ads there) and there is no visual filtering (at least currently) needed from my testing - I've been using this filter for a few months now and it works very well